### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -1,5 +1,5 @@
 name: Build
-description: "Build pipeline"
+description: "Build tools"
 inputs:
   go-version:
     description: "Go version to install"

--- a/.github/actions/generate-sdk/action.yaml
+++ b/.github/actions/generate-sdk/action.yaml
@@ -1,0 +1,13 @@
+name: Generate SDK
+description: "Generates the SDK"
+inputs:
+  go-version:
+    description: "Go version to install"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Download OAS
+      run: make download-oas
+    - name: Generate SDK
+      run: make generate-sdk

--- a/.github/actions/generate-sdk/action.yaml
+++ b/.github/actions/generate-sdk/action.yaml
@@ -8,6 +8,8 @@ runs:
   using: "composite"
   steps:
     - name: Download OAS
+      shell: bash
       run: make download-oas
     - name: Generate SDK
+      shell: bash
       run: make generate-sdk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,6 @@ jobs:
         uses: ./.github/actions/build
         with:
           go-version: ${{ env.GO_VERSION_BUILD }}
-      - name: (TEST) Check Go version
-        run: go version
       - name: Download OAS
         run: make download-oas
       - name: Generate SDK
@@ -41,8 +39,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - name: (TEST) Check Go version
-        run: go version
       - name: Lint
         if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
         working-directory: ./sdk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,9 +46,7 @@ jobs:
       - name: Lint
         if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
         working-directory: ./sdk
-        run: |
-          make lint skip-non-generated-files=true
-          scripts/check-sync-tidy.sh
+        run: make lint skip-non-generated-files=true
       - name: Test
         working-directory: ./sdk
         run: make test skip-non-generated-files=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,11 @@ env:
 jobs:
   main:
     name: CI
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        go-version: ['1.18', '1.19', '1.20']
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Install SSH Key
         uses: shimataro/ssh-key-action@v2
@@ -27,11 +31,20 @@ jobs:
         uses: ./.github/actions/build
         with:
           go-version: ${{ env.GO_VERSION_BUILD }}
+      - name: (TEST) Check Go version
+        run: go version
       - name: Download OAS
         run: make download-oas
       - name: Generate SDK
         run: make generate-sdk
+      - name: Install Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: (TEST) Check Go version
+        run: go version
       - name: Lint
+        if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
         working-directory: ./sdk
         run: |
           make lint skip-non-generated-files=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: CI Workflow
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  main:
+    name: CI
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        go-version: ['1.18', '1.19', '1.20']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install SSH Key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: ${{ vars.SSH_KNOWN_HOSTS }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Download OAS
+        run: make download-oas
+      - name: Generate SDK
+        run: make generate-sdk
+      - name: Lint
+        if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
+        working-directory: ./sdk
+        run: |
+          make lint
+          scripts/check-sync-tidy.sh
+      - name: Test
+        working-directory: ./sdk
+        run: make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: CI Workflow
 
 on: [pull_request, workflow_dispatch]
 
+env:
+  JAVA_VERSION: '11'
+
 jobs:
   main:
     name: CI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Lint
         if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
-        working-directory: ./sdk
+        working-directory: ./sdk-repo-cloned
         run: make lint skip-non-generated-files=true
       - name: Test
-        working-directory: ./sdk
+        working-directory: ./sdk-repo-cloned
         run: make test skip-non-generated-files=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+      - name: [TEST] Check Go version
+        run: go version
       - name: Lint
         if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
         working-directory: ./sdk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Lint
         if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
-        working-directory: ./sdk-repo-cloned
+        working-directory: ./sdk-repo-updated
         run: make lint skip-non-generated-files=true
       - name: Test
-        working-directory: ./sdk-repo-cloned
+        working-directory: ./sdk-repo-updated
         run: make test skip-non-generated-files=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,10 +31,8 @@ jobs:
         uses: ./.github/actions/build
         with:
           go-version: ${{ env.GO_VERSION_BUILD }}
-      - name: Download OAS
-        run: make download-oas
       - name: Generate SDK
-        run: make generate-sdk
+        uses: ./.github/actions/generate-sdk
       - name: Install Go ${{ matrix.go-version }}
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,7 @@ env:
 jobs:
   main:
     name: CI
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        go-version: ['1.18', '1.19', '1.20']
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Install SSH Key
         uses: shimataro/ssh-key-action@v2
@@ -35,14 +31,7 @@ jobs:
         run: make download-oas
       - name: Generate SDK
         run: make generate-sdk
-      - name: Install Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: (TESTT) Check Go version
-        run: go version
       - name: Lint
-        if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
         working-directory: ./sdk
         run: |
           make lint skip-non-generated-files=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: CI Workflow
 on: [pull_request, workflow_dispatch]
 
 env:
+  GO_VERSION_BUILD: '1.20'
   JAVA_VERSION: '11'
 
 jobs:
@@ -29,11 +30,15 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ env.GO_VERSION_BUILD }}
       - name: Download OAS
         run: make download-oas
       - name: Generate SDK
         run: make generate-sdk
+      - name: Install Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Lint
         if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
         working-directory: ./sdk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - name: (TEST) Check Go version
+      - name: (TESTT) Check Go version
         run: go version
       - name: Lint
         if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - name: [TEST] Check Go version
+      - name: (TEST) Check Go version
         run: go version
       - name: Lint
         if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,8 @@ jobs:
         if: ${{ matrix.go-version == '1.19' || matrix.go-version == '1.20' }}
         working-directory: ./sdk
         run: |
-          make lint
+          make lint skip-non-generated-files=true
           scripts/check-sync-tidy.sh
       - name: Test
         working-directory: ./sdk
-        run: make test
+        run: make test skip-non-generated-files=true

--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -31,10 +31,8 @@ jobs:
         uses: ./.github/actions/build
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Download OAS
-        run: make download-oas
       - name: Generate SDK
-        run: make generate-sdk
+        uses: ./.github/actions/generate-sdk
       - name: Push SDK
         env: 
           GH_REPO: 'stackitcloud/stackit-sdk-go'

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 bin/
 
 # Folders to support generation
-sdk/
+sdk-repo-cloned/
 oas/
 
 # Generated files

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 bin/
 
 # Folders to support generation
-sdk-repo-cloned/
+sdk-repo-updated/
 oas/
 
 # Generated files

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -163,4 +163,4 @@ done
 # Cleanup after SDK generation
 cd ${SDK_PATH}
 goimports -w ${SDK_PATH}/services/
-make lint
+make lint skip-non-generated-files=true

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -70,7 +70,7 @@ if [ -d ${ROOT_DIR}/sdk ]; then
     rm -rf ${ROOT_DIR}/sdk
     mkdir ${ROOT_DIR}/sdk
 fi
-git clone -b hs/lint-generated-files ${SDK_REPO_URL} ${SDK_REPO_LOCAL_PATH}
+git clone ${SDK_REPO_URL} ${SDK_REPO_LOCAL_PATH}
 
 # Install SDK project tools
 cd ${SDK_REPO_LOCAL_PATH}

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This script generates the SDK API modules
+# This script clones the SDK repo and updates it with the generated API modules
 # Pre-requisites: Java, goimports, Go
 set -eo pipefail
 

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 ROOT_DIR=$(git rev-parse --show-toplevel)
 GENERATOR_PATH="${ROOT_DIR}/scripts/bin"
 GENERATOR_LOG_LEVEL="error" # Must be a Java log level (error, warn, info...)
-SDK_REPO_LOCAL_PATH="${ROOT_DIR}/sdk-repo-cloned"
+SDK_REPO_LOCAL_PATH="${ROOT_DIR}/sdk-repo-updated"
 SDK_REPO_URL="https://github.com/stackitcloud/stackit-sdk-go.git"
 SDK_GO_VERSION="1.18"
 OAS_REPO=https://github.com/stackitcloud/stackit-api-specifications

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 ROOT_DIR=$(git rev-parse --show-toplevel)
 GENERATOR_PATH="${ROOT_DIR}/scripts/bin"
 GENERATOR_LOG_LEVEL="error" # Must be a Java log level (error, warn, info...)
-SDK_REPO_LOCAL_PATH="${ROOT_DIR}/sdk"
+SDK_REPO_LOCAL_PATH="${ROOT_DIR}/sdk-repo-cloned"
 SDK_REPO_URL="https://github.com/stackitcloud/stackit-sdk-go.git"
 SDK_GO_VERSION="1.18"
 OAS_REPO=https://github.com/stackitcloud/stackit-api-specifications

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -160,4 +160,3 @@ done
 # Cleanup after SDK generation
 cd ${SDK_REPO_LOCAL_PATH}
 goimports -w ${SDK_REPO_LOCAL_PATH}/services/
-make lint skip-non-generated-files=true

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -6,7 +6,6 @@ set -eo pipefail
 ROOT_DIR=$(git rev-parse --show-toplevel)
 GENERATOR_PATH="${ROOT_DIR}/scripts/bin"
 GENERATOR_LOG_LEVEL="error" # Must be a Java log level (error, warn, info...)
-PREPARE_SDK_PATH="${ROOT_DIR}/prepare-sdk"
 SDK_REPO_LOCAL_PATH="${ROOT_DIR}/sdk"
 SDK_REPO_URL="https://github.com/stackitcloud/stackit-sdk-go.git"
 SDK_GO_VERSION="1.18"

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -64,11 +64,10 @@ else
     echo "Download done."
 fi
 
-# Get latest version of SDK
-if [ -d ${ROOT_DIR}/sdk ]; then
-    echo "Old sdk was found, it will be removed"
-    rm -rf ${ROOT_DIR}/sdk
-    mkdir ${ROOT_DIR}/sdk
+# Clone SDK repo
+if [ -d ${SDK_REPO_LOCAL_PATH} ]; then
+    echo "Old SDK repo clone was found, it will be removed"
+    rm -rf ${SDK_REPO_LOCAL_PATH}
 fi
 git clone ${SDK_REPO_URL} ${SDK_REPO_LOCAL_PATH}
 

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -72,7 +72,7 @@ if [ -d ${ROOT_DIR}/sdk ]; then
     rm -rf ${ROOT_DIR}/sdk
     mkdir ${ROOT_DIR}/sdk
 fi
-git clone ${SDK_REPO} ${SDK_PATH}
+git clone -b hs/lint-generated-files ${SDK_REPO} ${SDK_PATH}
 
 # Install SDK project tools
 cd ${SDK_PATH}

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -24,7 +24,6 @@ if [[ ! ${sdk_services_backup_dir} || -d {sdk_services_backup_dir} ]]; then
 fi
 
 cleanup() {
-    rm -rf ${SDK_PATH}/.git
     rm -rf ${sdk_services_backup_dir}
     go env -w GOPRIVATE=${goprivate_backup}
 }

--- a/scripts/sdk-create-pr.sh
+++ b/scripts/sdk-create-pr.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 ROOT_DIR=$(git rev-parse --show-toplevel)
 COMMIT_NAME="SDK Generator Bot"
 COMMIT_EMAIL="noreply@stackit.de"
-SDK_REPO_LOCAL_PATH="${ROOT_DIR}/sdk-repo-cloned" # Comes from generate-sdk.sh
+SDK_REPO_LOCAL_PATH="${ROOT_DIR}/sdk-repo-updated" # Comes from generate-sdk.sh
 REPO_URL_SSH="git@github.com:stackitcloud/stackit-sdk-go.git"
 REPO_BRANCH="main"
 

--- a/scripts/sdk-create-pr.sh
+++ b/scripts/sdk-create-pr.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 ROOT_DIR=$(git rev-parse --show-toplevel)
 COMMIT_NAME="SDK Generator Bot"
 COMMIT_EMAIL="noreply@stackit.de"
-FOLDER_TO_PUSH_PATH="${ROOT_DIR}/sdk" # Comes from generate-sdk.sh
+FOLDER_TO_PUSH_PATH="${ROOT_DIR}/sdk-repo-cloned" # Comes from generate-sdk.sh
 REPO_URL_SSH="git@github.com:stackitcloud/stackit-sdk-go.git"
 REPO_BRANCH="main"
 

--- a/scripts/sdk-create-pr.sh
+++ b/scripts/sdk-create-pr.sh
@@ -29,8 +29,12 @@ fi
 # Delete temp directory on exit
 trap "rm -rf ${work_dir}" EXIT
 
-# Where the git repo will be created
-mkdir ${work_dir}/git_repo
+mkdir ${work_dir}/git_repo    # Where the git repo will be created
+mkdir ${work_dir}/sdk_to_push # Copy of SDK to push
+
+# Prepare SDK to push
+cp -a ${SDK_REPO_LOCAL_PATH}/. ${work_dir}/sdk_to_push
+rm -rf ${work_dir}/sdk_to_push/.git
 
 # Initialize git repo
 cd ${work_dir}/git_repo
@@ -42,7 +46,7 @@ git config user.email "${COMMIT_EMAIL}"
 # Removal of pulled data is necessary because the old version may have files
 # that were deleted in the new version
 rm -rf ./*
-cp -a ${SDK_REPO_LOCAL_PATH}/. ./
+cp -a ${work_dir}/sdk_to_push/. ./
 
 # Create PR with new SDK if there are changes
 git switch -c "$1"

--- a/scripts/sdk-create-pr.sh
+++ b/scripts/sdk-create-pr.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 ROOT_DIR=$(git rev-parse --show-toplevel)
 COMMIT_NAME="SDK Generator Bot"
 COMMIT_EMAIL="noreply@stackit.de"
-FOLDER_TO_PUSH_PATH="${ROOT_DIR}/sdk-repo-cloned" # Comes from generate-sdk.sh
+SDK_REPO_LOCAL_PATH="${ROOT_DIR}/sdk-repo-cloned" # Comes from generate-sdk.sh
 REPO_URL_SSH="git@github.com:stackitcloud/stackit-sdk-go.git"
 REPO_BRANCH="main"
 
@@ -14,7 +14,7 @@ if [ $# -ne 4 ]; then
     exit 1
 fi
 
-if [ ! -d ${FOLDER_TO_PUSH_PATH} ]; then
+if [ ! -d ${SDK_REPO_LOCAL_PATH} ]; then
     echo "sdk to commit not found in root. Please run make generate-sdk"
     exit 1
 fi
@@ -42,7 +42,7 @@ git config user.email "${COMMIT_EMAIL}"
 # Removal of pulled data is necessary because the old version may have files
 # that were deleted in the new version
 rm -rf ./*
-cp -a ${FOLDER_TO_PUSH_PATH}/. ./
+cp -a ${SDK_REPO_LOCAL_PATH}/. ./
 
 # Create PR with new SDK if there are changes
 git switch -c "$1"


### PR DESCRIPTION
Generates, lints and tests the SDK
- `make generate-sdk` now does not delete .sdk after cloning the repo.
  - Changed the folder to which it's cloned, so it's more obvious it's a clone of the repo
  - Modified `sdk-create-pr.sh` accordingly
- Moved SDK generation to separate action