### PR TITLE
Increase number-like data types' precision

### DIFF
--- a/templates/model_simple.mustache
+++ b/templates/model_simple.mustache
@@ -15,12 +15,18 @@ type {{classname}} struct {
 {{#description}}
 	// {{{.}}}
 {{/description}}
+{{#isShort}}
+	// Can be cast to int32 without loss of precision.
+{{/isShort}}
+{{#isFloat}}
+	// Can be cast to float32 without loss of precision.
+{{/isFloat}}
 {{#deprecated}}
 	// Deprecated
 {{/deprecated}}
 {{#required}}
     // REQUIRED
 {{/required}}
-	{{name}} *{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 }


### PR DESCRIPTION
To avoid breaking changes in the SDK in changes to precision in the OAS that are allowed (eg, reducing precision in fields only used in responses)

The different number types in OAS are described [here](https://swagger.io/docs/specification/data-models/data-types/). The aim is to have all `"type": "number` generated as `float64` and all `"type": "integer"` fields generated as int64.

To check that this is working, you can add one of each possible number-like data-type to an OAS structure and generate the SDK:
```
"number": {
  "type": "number"
},
"float": {
  "type": "number",
  "format": "float"
},
"double": {
  "type": "number",
  "format": "double"
},
"integer": {
  "type": "integer"
},
"int32": {
  "type": "integer",
  "format": "int32"
},
"int64": {
  "type": "integer",
  "format": "int64"
}
```