### PR TITLE
Change default client to not use `http.DefaultClient`

### DIFF
--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -66,7 +66,7 @@ func NewAPIClient(opts ...config.ConfigurationOption) (*APIClient, error) {
 	}
 
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = http.DefaultClient
+		cfg.HTTPClient = &http.Client{}
 	}
 
 	authRoundTripper, err := auth.SetupAuth(cfg)


### PR DESCRIPTION
Fixes https://github.com/stackitcloud/stackit-sdk-go/issues/236