### PR TITLE
Extend Go templates to support `nullable` fields and `additionalProperties`

### DIFF
--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -157,7 +157,7 @@ for service_json in ${ROOT_DIR}/oas/*.json; do
         --git-user-id ${GIT_USER_ID} \
         --git-repo-id ${GIT_REPO_ID} \
         --global-property apis,models,modelTests=true,modelDocs=false,apiDocs=false,supportingFiles \
-        --additional-properties=isGoSubmodule=true
+        --additional-properties=isGoSubmodule=true,enumClassPrefix=true
     rm ${SERVICES_FOLDER}/${service}/.openapi-generator-ignore
     rm ${SERVICES_FOLDER}/${service}/.openapi-generator/FILES
 

--- a/templates/model_simple.mustache
+++ b/templates/model_simple.mustache
@@ -34,6 +34,9 @@ type {{classname}} struct {
     // REQUIRED
 {{/required}}
 	{{name}} *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+{{#isAdditionalPropertiesTrue}}
+	AdditionalProperties map[string]interface{}
+{{/isAdditionalPropertiesTrue}}
 {{/vars}}
 }
 
@@ -94,7 +97,7 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{/isNullable}}
 {{^isNullable}}
 	var {{nameInCamelCase}} {{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}} = {{{.}}}
-	this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
+	this.{{name}} = &{{nameInCamelCase}}
 {{/isNullable}}
 {{/isReadOnly}}
 {{/vendorExtensions.x-golang-is-container}}
@@ -139,13 +142,13 @@ func (o *{{classname}}) Get{{name}}() *{{#isNumber}}float64{{/isNumber}}{{#isFlo
 {{#deprecated}}
 // Deprecated
 {{/deprecated}}
-func (o *{{classname}}) Get{{name}}Ok() (*{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}, bool) {
+func (o *{{classname}}) Get{{name}}Ok() (*{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}, bool) {
 	if o == nil{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
 {{^isFreeFormObject}}
 		return nil, false
 	{{/isFreeFormObject}}
 	{{#isFreeFormObject}}
-		return {{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}}{}, false
+		return &{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}{}, false
 	{{/isFreeFormObject}}
 	}
 {{#isNullable}}
@@ -157,7 +160,7 @@ func (o *{{classname}}) Get{{name}}Ok() (*{{^isArray}}{{^isFreeFormObject}}*{{/i
 {{/vendorExtensions.x-golang-is-container}}
 {{/isNullable}}
 {{^isNullable}}
-	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+	return o.{{name}}, true
 {{/isNullable}}
 }
 
@@ -217,7 +220,7 @@ func (o *{{classname}}) Get{{name}}Ok() (*{{#isNumber}}float64{{/isNumber}}{{#is
 		return nil, false
 	{{/isFreeFormObject}}
 	{{#isFreeFormObject}}
-		return *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}{}, false
+		return &{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}{}, false
 	{{/isFreeFormObject}}
 	}
 {{#isNullable}}

--- a/templates/model_simple.mustache
+++ b/templates/model_simple.mustache
@@ -37,6 +37,7 @@ type {{classname}} struct {
 {{/vars}}
 }
 
+
 {{#isAdditionalPropertiesTrue}}
 type _{{{classname}}} {{{classname}}}
 
@@ -51,7 +52,7 @@ type _{{{classname}}} {{{classname}}}
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}}, {{/-last}}{{/requiredVars}}) *{{classname}} {
+func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}}{{^-last}}, {{/-last}}{{/requiredVars}}) *{{classname}} {
 	this := {{classname}}{}
 {{#allVars}}
 {{#required}}
@@ -63,10 +64,10 @@ func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}
 {{^isReadOnly}}
 {{#isNullable}}
 	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
-	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+	this.{{name}} = *New{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}}(&{{nameInCamelCase}})
 {{/isNullable}}
 {{^isNullable}}
-	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	var {{nameInCamelCase}} {{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}} = {{{.}}}
 	this.{{name}} = &{{nameInCamelCase}}
 {{/isNullable}}
 {{/isReadOnly}}
@@ -89,10 +90,10 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{#isNullable}}
 {{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
 	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
-	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+	this.{{name}} = *New{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}}(&{{nameInCamelCase}})
 {{/isNullable}}
 {{^isNullable}}
-	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	var {{nameInCamelCase}} {{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}} = {{{.}}}
 	this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
 {{/isNullable}}
 {{/isReadOnly}}
@@ -111,9 +112,9 @@ func New{{classname}}WithDefaults() *{{classname}} {
 {{#deprecated}}
 // Deprecated
 {{/deprecated}}
-func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+func (o *{{classname}}) Get{{name}}() *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}} {
 	if o == nil{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
-		var ret {{vendorExtensions.x-go-base-type}}
+		var ret *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}
 		return ret
 	}
 
@@ -138,13 +139,13 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 {{#deprecated}}
 // Deprecated
 {{/deprecated}}
-func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
+func (o *{{classname}}) Get{{name}}Ok() (*{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}, bool) {
 	if o == nil{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
 {{^isFreeFormObject}}
 		return nil, false
 	{{/isFreeFormObject}}
 	{{#isFreeFormObject}}
-		return {{vendorExtensions.x-go-base-type}}{}, false
+		return {{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}}{}, false
 	{{/isFreeFormObject}}
 	}
 {{#isNullable}}
@@ -164,7 +165,7 @@ func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/is
 {{#deprecated}}
 // Deprecated
 {{/deprecated}}
-func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+func (o *{{classname}}) Set{{name}}(v *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}) {
 {{#isNullable}}
 {{#vendorExtensions.x-golang-is-container}}
 	o.{{name}} = v
@@ -184,9 +185,9 @@ func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
 {{#deprecated}}
 // Deprecated
 {{/deprecated}}
-func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+func (o *{{classname}}) Get{{name}}() *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}} {
 	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}.Get()){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
-		var ret {{vendorExtensions.x-go-base-type}}
+		var ret *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}
 		return ret
 	}
 {{#isNullable}}
@@ -194,11 +195,11 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 	return o.{{name}}
 {{/vendorExtensions.x-golang-is-container}}
 {{^vendorExtensions.x-golang-is-container}}
-	return *o.{{name}}.Get()
+	return o.{{name}}.Get()
 {{/vendorExtensions.x-golang-is-container}}
 {{/isNullable}}
 {{^isNullable}}
-	return {{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}o.{{name}}
+	return o.{{name}}
 {{/isNullable}}
 }
 
@@ -210,13 +211,13 @@ func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
 {{#deprecated}}
 // Deprecated
 {{/deprecated}}
-func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
+func (o *{{classname}}) Get{{name}}Ok() (*{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}, bool) {
 	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
 	{{^isFreeFormObject}}
 		return nil, false
 	{{/isFreeFormObject}}
 	{{#isFreeFormObject}}
-		return {{vendorExtensions.x-go-base-type}}{}, false
+		return *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}{}, false
 	{{/isFreeFormObject}}
 	}
 {{#isNullable}}
@@ -241,21 +242,21 @@ func (o *{{classname}}) Has{{name}}() bool {
 	return false
 }
 
-// Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
+// Set{{name}} gets a reference to the given {{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}} and assigns it to the {{name}} field.
 {{#deprecated}}
 // Deprecated
 {{/deprecated}}
-func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+func (o *{{classname}}) Set{{name}}(v *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{vendorExtensions.x-go-base-type}}{{/isNumeric}}) {
 {{#isNullable}}
 {{#vendorExtensions.x-golang-is-container}}
 	o.{{name}} = v
 {{/vendorExtensions.x-golang-is-container}}
 {{^vendorExtensions.x-golang-is-container}}
-	o.{{name}}.Set({{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}v)
+	o.{{name}}.Set(v)
 {{/vendorExtensions.x-golang-is-container}}
 {{/isNullable}}
 {{^isNullable}}
-	o.{{name}} = {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}v
+	o.{{name}} = v
 {{/isNullable}}
 }
 {{#isNullable}}
@@ -394,7 +395,7 @@ func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 	{{#deprecated}}
 		// Deprecated
 	{{/deprecated}}
-		{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{{baseName}}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{{baseName}}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+		{{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}} `json:"{{{baseName}}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{{baseName}}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 	{{/vars}}
 	}
 

--- a/templates/model_simple.mustache
+++ b/templates/model_simple.mustache
@@ -1,3 +1,7 @@
+// checks if the {{classname}} type satisfies the MappedNullable interface at compile time
+var _ MappedNullable = &{{classname}}{}
+
+// {{classname}} {{{description}}}{{^description}}struct for {{{classname}}}{{/description}}
 type {{classname}} struct {
 {{#parent}}
 {{^isMap}}
@@ -32,3 +36,494 @@ type {{classname}} struct {
 	{{name}} *{{#isNumber}}float64{{/isNumber}}{{#isFloat}}float64{{/isFloat}}{{#isDouble}}float64{{/isDouble}}{{#isInteger}}int64{{/isInteger}}{{#isLong}}int64{{/isLong}}{{^isNumeric}}{{{dataType}}}{{/isNumeric}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 }
+
+{{#isAdditionalPropertiesTrue}}
+type _{{{classname}}} {{{classname}}}
+
+{{/isAdditionalPropertiesTrue}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+type _{{{classname}}} {{{classname}}}
+
+{{/hasRequired}}
+{{/isAdditionalPropertiesTrue}}
+// New{{classname}} instantiates a new {{classname}} object
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed
+func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}}, {{/-last}}{{/requiredVars}}) *{{classname}} {
+	this := {{classname}}{}
+{{#allVars}}
+{{#required}}
+	this.{{name}} = {{nameInCamelCase}}
+{{/required}}
+{{^required}}
+{{#defaultValue}}
+{{^vendorExtensions.x-golang-is-container}}
+{{^isReadOnly}}
+{{#isNullable}}
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = &{{nameInCamelCase}}
+{{/isNullable}}
+{{/isReadOnly}}
+{{/vendorExtensions.x-golang-is-container}}
+{{/defaultValue}}
+{{/required}}
+{{/allVars}}
+	return &this
+}
+
+// New{{classname}}WithDefaults instantiates a new {{classname}} object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func New{{classname}}WithDefaults() *{{classname}} {
+	this := {{classname}}{}
+{{#vars}}
+{{#defaultValue}}
+{{^vendorExtensions.x-golang-is-container}}
+{{^isReadOnly}}
+{{#isNullable}}
+{{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
+{{/isNullable}}
+{{/isReadOnly}}
+{{/vendorExtensions.x-golang-is-container}}
+{{/defaultValue}}
+{{/vars}}
+	return &this
+}
+
+{{#vars}}
+{{#required}}
+// Get{{name}} returns the {{name}} field value
+{{#isNullable}}
+// If the value is explicit nil, the zero value for {{vendorExtensions.x-go-base-type}} will be returned
+{{/isNullable}}
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+	if o == nil{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-go-base-type}}
+		return ret
+	}
+
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return o.{{name}}
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return *o.{{name}}.Get()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
+	if o == nil{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+{{^isFreeFormObject}}
+		return nil, false
+	{{/isFreeFormObject}}
+	{{#isFreeFormObject}}
+		return {{vendorExtensions.x-go-base-type}}{}, false
+	{{/isFreeFormObject}}
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+{{/isNullable}}
+}
+
+// Set{{name}} sets field value
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	o.{{name}} = v
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	o.{{name}}.Set(&v)
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = v
+{{/isNullable}}
+}
+
+{{/required}}
+{{^required}}
+// Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}.Get()){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-go-base-type}}
+		return ret
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return o.{{name}}
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return *o.{{name}}.Get()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return {{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{vendorExtensions.x-go-base-type}}, bool) {
+	if o == nil{{^isNullable}} || IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}} || IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+	{{^isFreeFormObject}}
+		return nil, false
+	{{/isFreeFormObject}}
+	{{#isFreeFormObject}}
+		return {{vendorExtensions.x-go-base-type}}{}, false
+	{{/isFreeFormObject}}
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}o.{{name}}, true
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}, true
+{{/isNullable}}
+}
+
+// Has{{name}} returns a boolean if a field has been set.
+func (o *{{classname}}) Has{{name}}() bool {
+	if o != nil && {{^isNullable}}!IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}!IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}o.{{name}}.IsSet(){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		return true
+	}
+
+	return false
+}
+
+// Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
+{{#deprecated}}
+// Deprecated
+{{/deprecated}}
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	o.{{name}} = v
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	o.{{name}}.Set({{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}v)
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = {{^isArray}}{{^isFreeFormObject}}&{{/isFreeFormObject}}{{/isArray}}v
+{{/isNullable}}
+}
+{{#isNullable}}
+{{^vendorExtensions.x-golang-is-container}}
+// Set{{name}}Nil sets the value for {{name}} to be an explicit nil
+func (o *{{classname}}) Set{{name}}Nil() {
+	o.{{name}}.Set(nil)
+}
+
+// Unset{{name}} ensures that no value is present for {{name}}, not even an explicit nil
+func (o *{{classname}}) Unset{{name}}() {
+	o.{{name}}.Unset()
+}
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+
+{{/required}}
+{{/vars}}
+{{#vendorExtensions.x-go-generate-marshal-json}}
+func (o {{classname}}) MarshalJSON() ([]byte, error) {
+	toSerialize,err := o.ToMap()
+	if err != nil {
+		return []byte{}, err
+	}
+	return json.Marshal(toSerialize)
+}
+
+{{/vendorExtensions.x-go-generate-marshal-json}}
+func (o {{classname}}) ToMap() (map[string]interface{}, error) {
+	toSerialize := {{#isArray}}make([]interface{}, len(o.Items)){{/isArray}}{{^isArray}}map[string]interface{}{}{{/isArray}}
+	{{#parent}}
+	{{^isMap}}
+	{{^isArray}}
+	serialized{{parent}}, err{{parent}} := json.Marshal(o.{{parent}})
+	if err{{parent}} != nil {
+		return map[string]interface{}{}, err{{parent}}
+	}
+	err{{parent}} = json.Unmarshal([]byte(serialized{{parent}}), &toSerialize)
+	if err{{parent}} != nil {
+		return map[string]interface{}{}, err{{parent}}
+	}
+	{{/isArray}}
+	{{/isMap}}
+	{{#isArray}}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	{{/isArray}}
+	{{/parent}}
+	{{#vars}}
+	{{! if argument is nullable, only serialize it if it is set}}
+	{{#isNullable}}
+	{{#vendorExtensions.x-golang-is-container}}
+	{{! support for container fields is not ideal at this point because of lack of Nullable* types}}
+	if o.{{name}} != nil {
+		toSerialize["{{{baseName}}}"] = o.{{name}}
+	}
+	{{/vendorExtensions.x-golang-is-container}}
+	{{^vendorExtensions.x-golang-is-container}}
+	{{#required}}
+	toSerialize["{{{baseName}}}"] = o.{{name}}.Get()
+	{{/required}}
+	{{^required}}
+	if o.{{name}}.IsSet() {
+		toSerialize["{{{baseName}}}"] = o.{{name}}.Get()
+	}
+	{{/required}}
+	{{/vendorExtensions.x-golang-is-container}}
+	{{/isNullable}}
+	{{! if argument is not nullable, don't set it if it is nil}}
+	{{^isNullable}}
+	{{#required}}
+	toSerialize["{{{baseName}}}"] = o.{{name}}
+	{{/required}}
+	{{^required}}
+	if !IsNil(o.{{name}}) {
+		toSerialize["{{{baseName}}}"] = o.{{name}}
+	}
+	{{/required}}
+	{{/isNullable}}
+	{{/vars}}
+	{{#isAdditionalPropertiesTrue}}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
+	{{/isAdditionalPropertiesTrue}}
+	return toSerialize, nil
+}
+
+{{#vendorExtensions.x-go-generate-unmarshal-json}}
+{{#isAdditionalPropertiesTrue}}
+func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
+{{/isAdditionalPropertiesTrue}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
+{{/hasRequired}}
+{{/isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+	// This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+{{#requiredVars}}
+		"{{baseName}}",
+{{/requiredVars}}
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(data, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+{{/hasRequired}}
+{{#isAdditionalPropertiesTrue}}
+{{#parent}}
+{{^isMap}}
+	type {{classname}}WithoutEmbeddedStruct struct {
+	{{#vars}}
+	{{^-first}}
+	{{/-first}}
+	{{#description}}
+		// {{{.}}}
+	{{/description}}
+	{{#deprecated}}
+		// Deprecated
+	{{/deprecated}}
+		{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{{baseName}}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{{baseName}}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{/vars}}
+	}
+
+	var{{{classname}}}WithoutEmbeddedStruct := {{{classname}}}WithoutEmbeddedStruct{}
+
+	err = json.Unmarshal(data, &var{{{classname}}}WithoutEmbeddedStruct)
+	if err == nil {
+		var{{{classname}}} := _{{{classname}}}{}
+		{{#vars}}
+		var{{{classname}}}.{{{name}}} = var{{{classname}}}WithoutEmbeddedStruct.{{{name}}}
+		{{/vars}}
+		*o = {{{classname}}}(var{{{classname}}})
+	} else {
+		return err
+	}
+
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(data, &var{{{classname}}})
+	if err == nil {
+		o.{{{parent}}} = var{{{classname}}}.{{{parent}}}
+	} else {
+		return err
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+
+		// remove fields from embedded structs
+		reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
+		for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
+			t := reflect{{{parent}}}.Type().Field(i)
+
+			if jsonTag := t.Tag.Get("json"); jsonTag != "" {
+				fieldName := ""
+				if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
+					fieldName = jsonTag[:commaIdx]
+				} else {
+					fieldName = jsonTag
+				}
+				if fieldName != "AdditionalProperties" {
+					delete(additionalProperties, fieldName)
+				}
+			}
+		}
+
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/isMap}}
+{{#isMap}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(data, &var{{{classname}}})
+
+	if err != nil {
+		return err
+	}
+
+	*o = {{{classname}}}(var{{{classname}}})
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/isMap}}
+{{/parent}}
+{{^parent}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(data, &var{{{classname}}})
+
+	if err != nil {
+		return err
+	}
+
+	*o = {{{classname}}}(var{{{classname}}})
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/parent}}
+{{/isAdditionalPropertiesTrue}}
+{{#isAdditionalPropertiesTrue}}
+}
+
+{{/isAdditionalPropertiesTrue}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&var{{{classname}}})
+
+	if err != nil {
+		return err
+	}
+
+	*o = {{{classname}}}(var{{{classname}}})
+
+	return err
+}
+
+{{/hasRequired}}
+{{/isAdditionalPropertiesTrue}}
+{{#isArray}}
+func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
+	return json.Unmarshal(data, &o.Items)
+}
+
+{{/isArray}}
+{{/vendorExtensions.x-go-generate-unmarshal-json}}
+{{>nullable_model}}


### PR DESCRIPTION
- In the first commit (564c14b8705b5c456448bf55060ac0125a45bfbb) I just copied the [default Go templates from the OpenAPITools generator](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/go/model_simple.mustache)
- You can check what actually changed by opening the following commits individually

> [!IMPORTANT]
> This will cause a lot of changes in the SDK, but will should only be the addition of utils and functionality to every model.
> No current functionality should change or be removed.
> Please test this locally by running `make download-oas` followed by `make generate-sdk`, and running the examples for some services