### PR TITLE
Fix unit test template to support more types of path parameters

### DIFF
--- a/templates/go/api_test.mustache
+++ b/templates/go/api_test.mustache
@@ -28,7 +28,7 @@ func Test_{{packageName}}_{{classname}}Service(t *testing.T) {
 {{#operation}}
 	t.Run("Test {{classname}}Service {{{nickname}}}", func(t *testing.T) {
 		path := "{{{path}}}"{{#pathParams}}
-		{{paramName}}Value := {{#isString}}"{{paramName}}"{{/isString}}{{#isInteger}}int32(12345){{/isInteger}}{{^isString}}{{^isInteger}}{{defaultValue}}{{/isInteger}}{{/isString}}
+		{{paramName}}Value := {{#isString}}"{{paramName}}"{{/isString}}{{#isNumber}}123{{/isNumber}}{{#isFloat}}float32(123){{/isFloat}}{{#isDouble}}float64(123){{/isDouble}}{{#isInteger}}int32(123){{/isInteger}}{{#isLong}}int64(123){{/isLong}}{{^isString}}{{^isInteger}}{{defaultValue}}{{/isInteger}}{{/isString}}
 		path = strings.Replace(path, "{"+"{{baseName}}"+"}", url.PathEscape(ParameterValueToString({{paramName}}Value, "{{paramName}}")), -1){{/pathParams}}
 
 		test{{classname}}ServeMux := http.NewServeMux()
@@ -79,7 +79,7 @@ func Test_{{packageName}}_{{classname}}Service(t *testing.T) {
 		{{#allParams}}
 		{{#required}}
 		{{#isPathParam}}
-		{{paramName}} := {{#isString}}"{{paramName}}"{{/isString}}{{#isInteger}}int32(12345){{/isInteger}}{{^isString}}{{^isInteger}}{{defaultValue}}{{/isInteger}}{{/isString}}
+		{{paramName}} := {{#isString}}"{{paramName}}"{{/isString}}{{#isNumber}}123{{/isNumber}}{{#isFloat}}float32(123){{/isFloat}}{{#isDouble}}float64(123){{/isDouble}}{{#isInteger}}int32(123){{/isInteger}}{{#isLong}}int64(123){{/isLong}}{{^isString}}{{^isInteger}}{{defaultValue}}{{/isInteger}}{{/isString}}
 		{{/isPathParam}}
 		{{^isPathParam}}
 		{{#isPrimitiveType}}


### PR DESCRIPTION
- Currently if the path parameter in the OAS was any other than `string` or `int32` it would break the SDK generation