### PR TITLE
Skip unit test of iaas SDK due to unsupported validations

### DIFF
--- a/scripts/sdk-create-pr.sh
+++ b/scripts/sdk-create-pr.sh
@@ -88,10 +88,16 @@ for service_path in ${work_dir}/sdk_to_push/services/*; do
             echo "! Linting failed for $service. THE UPDATE OF THIS SERVICE WILL BE SKIPPED."
             continue
         }
-        make test skip-non-generated-files=true service=$service || {
-            echo "! Testing failed for $service. THE UPDATE OF THIS SERVICE WILL BE SKIPPED."
-            continue
-        }
+        # Our unit test template fails because it doesn't support fields with validations,
+        # such as the UUID component used by IaaS. We introduce this hardcoded skip until we fix it
+        if [ "${service}" = "iaas" ] || [ "${service}" = "iaasalpha" ]; then
+            echo ">> Skipping tests of $service service"
+        else
+            make test skip-non-generated-files=true service=$service || {
+                echo "! Testing failed for $service. THE UPDATE OF THIS SERVICE WILL BE SKIPPED."
+                continue
+            }
+        fi
 
         if [[ "$BRANCH_PREFIX" != "main" ]]; then
             git switch main # This is needed to create a new branch for the service without including the previously committed files


### PR DESCRIPTION
- Similar to what is present in the `make test` script in the SDK: [test-go.sh](https://github.com/stackitcloud/stackit-sdk-go/blob/bcb98652a510fbdd13f0eef7da0b368ab96140ed/scripts/test-go.sh#L52)