### PR TITLE
special handling for format tag in enums that lead to broken code

### DIFF
--- a/templates/go/model_enum.mustache
+++ b/templates/go/model_enum.mustache
@@ -1,5 +1,5 @@
 // {{{classname}}} {{{description}}}{{^description}}the model '{{{classname}}}'{{/description}}
-type {{{classname}}} {{{format}}}{{^format}}{{dataType}}{{/format}}
+type {{{classname}}} {{dataType}}
 
 // List of {{{name}}}
 const (
@@ -22,7 +22,7 @@ var Allowed{{{classname}}}EnumValues = []{{{classname}}}{
 }
 
 func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
-	var value {{{format}}}{{^format}}{{dataType}}{{/format}}
+	var value {{dataType}}
 	err := json.Unmarshal(src, &value)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
 
 // New{{{classname}}}FromValue returns a pointer to a valid {{{classname}}}
 // for the value passed as argument, or an error if the value passed is not allowed by the enum
-func New{{{classname}}}FromValue(v {{{format}}}{{^format}}{{dataType}}{{/format}}) (*{{{classname}}}, error) {
+func New{{{classname}}}FromValue(v {{dataType}}) (*{{{classname}}}, error) {
 	ev := {{{classname}}}(v)
 	if ev.IsValid() {
 		return &ev, nil


### PR DESCRIPTION
Definitions of the following structure lead to broken code in the generator:

```go
"MyEnum": {
        "enum": [
          "foo",
          "bar",
          baz"
        ],
        "format": "enum",
        "type": "string"
      }
```
The additional format specifier is copied verbatim as the base datatype for the enum, leading to broken code if the type is not a builtin type.
The fix for this is to remove the support for the format specifier in the template. This is is a valid approach, because:
* openapi only supports enum for strings, i.e. the basetype always have to be a string
* the format specifier is open-valued (see [here](https://swagger.io/docs/specification/v3_0/data-models/data-types/#strings)), i.e. the application is generator specific
* the base type for the enum can still be changed using the type attribute (even if no enum values can be defined for types other than string!)
* the change has no effect on the current generated API
