### PR TITLE
feat: use fixed sdk version commit ref from file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ROOT_DIR              ?= $(shell git rev-parse --show-toplevel)
 SCRIPTS_BASE          ?= $(ROOT_DIR)/scripts
-API_VERSION           ?= $(shell cat api_version|grep -v '^#'|head -n 1)
+API_VERSION           ?= $(shell cat api_version|grep -v '^\#'|head -n 1)
 SDK_BRANCH            ?= main
 
 # SETUP AND TOOL INITIALIZATION TASKS

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ROOT_DIR              ?= $(shell git rev-parse --show-toplevel)
 SCRIPTS_BASE          ?= $(ROOT_DIR)/scripts
 API_VERSION           ?= $(shell cat api_version|grep -v '^#'|head -n 1)
+SDK_BRANCH            ?= main
 
 # SETUP AND TOOL INITIALIZATION TASKS
 project-help:
@@ -12,6 +13,7 @@ project-tools:
 # GENERATE
 download-oas:
 	@$(SCRIPTS_BASE)/download-oas.sh "$(OAS_REPO_NAME)" "$(OAS_REPO)" "$(ALLOW_ALPHA)" "$(API_VERSION)"
+
 generate-sdk:
-	@$(SCRIPTS_BASE)/generate-sdk/generate-sdk.sh "$(GIT_HOST)" "$(GIT_USER_ID)" "$(GIT_REPO_ID)" "$(SDK_REPO_URL)" "$(LANGUAGE)"
+	@$(SCRIPTS_BASE)/generate-sdk/generate-sdk.sh "$(GIT_HOST)" "$(GIT_USER_ID)" "$(GIT_REPO_ID)" "$(SDK_REPO_URL)" "$(LANGUAGE)" "$(SDK_BRANCH)"
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ROOT_DIR              ?= $(shell git rev-parse --show-toplevel)
 SCRIPTS_BASE          ?= $(ROOT_DIR)/scripts
+API_VERSION           ?= $(shell cat api_version|grep -v '^#'|head -n 1)
 
 # SETUP AND TOOL INITIALIZATION TASKS
 project-help:
@@ -10,7 +11,7 @@ project-tools:
 
 # GENERATE
 download-oas:
-	@$(SCRIPTS_BASE)/download-oas.sh "$(OAS_REPO_NAME)" "$(OAS_REPO)" "$(ALLOW_ALPHA)"
+	@$(SCRIPTS_BASE)/download-oas.sh "$(OAS_REPO_NAME)" "$(OAS_REPO)" "$(ALLOW_ALPHA)" "$(API_VERSION)"
 generate-sdk:
 	@$(SCRIPTS_BASE)/generate-sdk/generate-sdk.sh "$(GIT_HOST)" "$(GIT_USER_ID)" "$(GIT_REPO_ID)" "$(SDK_REPO_URL)" "$(LANGUAGE)"
 

--- a/api_version
+++ b/api_version
@@ -1,0 +1,3 @@
+# 2e3768b7b65237391fc587eddd559451f2b183a6
+# comments are allowed!
+main

--- a/scripts/download-oas.sh
+++ b/scripts/download-oas.sh
@@ -6,6 +6,7 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 OAS_REPO_NAME=$1
 OAS_REPO=$2
 ALLOW_ALPHA=$3
+OAS_API_VERSION=$4
 
 if [[ -z ${OAS_REPO_NAME} ]]; then
     echo "Repo name is empty, default public OAS repo name will be used."
@@ -15,6 +16,11 @@ fi
 if [[ ! ${OAS_REPO} || -d ${OAS_REPO} ]]; then
     echo "Repo argument is empty, default public OAS repo will be used."
     OAS_REPO="https://github.com/stackitcloud/${OAS_REPO_NAME}.git"
+fi
+
+if [[ -z ${OAS_API_VERSION} ]]; then
+    echo "No API version passed, main branch will be used"
+    OAS_API_VERSION="main"
 fi
 
 # Create temp directory to clone OAS repo
@@ -34,6 +40,11 @@ fi
 mkdir ${ROOT_DIR}/oas
 cd ${work_dir}
 git clone ${OAS_REPO} --quiet
+
+echo "Using api version ${OAS_API_VERSION}"
+cd ${OAS_REPO_NAME}
+git checkout --quiet ${OAS_API_VERSION}
+cd -
 
 for service_dir in ${work_dir}/${OAS_REPO_NAME}/services/*; do
     max_version_dir=""

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -9,6 +9,7 @@ GIT_USER_ID=$2
 GIT_REPO_ID=$3
 SDK_REPO_URL=$4
 LANGUAGE=$5
+SDK_BRANCH=$6
 
 # Global variables
 ROOT_DIR=$(git rev-parse --show-toplevel)
@@ -30,6 +31,11 @@ fi
 if [[ -z ${LANGUAGE} ]]; then
     echo "LANGUAGE not specified, default will be used."
     LANGUAGE="go"
+fi
+
+if [[ -z ${SDK_BRANCH}  ]]; then
+    echo "SDK_BRANCH not specified, main branch will be used."
+    SDK_BRANCH=main
 fi
 
 # Check dependencies
@@ -78,7 +84,7 @@ go)
 
     source ${LANGUAGE_GENERATORS_FOLDER_PATH}/${LANGUAGE}.sh
     # Usage: generate_go_sdk GENERATOR_PATH GIT_HOST GIT_USER_ID [GIT_REPO_ID] [SDK_REPO_URL]
-    generate_go_sdk ${jar_path} ${GIT_HOST} ${GIT_USER_ID} ${GIT_REPO_ID} ${SDK_REPO_URL}
+    generate_go_sdk "${jar_path}" "${GIT_HOST}" "${GIT_USER_ID}" "${GIT_REPO_ID}" "${SDK_REPO_URL}" "${SDK_BRANCH}"
     ;;
 python)
     echo -e "\n>> Generating the Python SDK..."

--- a/scripts/generate-sdk/languages/go.sh
+++ b/scripts/generate-sdk/languages/go.sh
@@ -27,6 +27,7 @@ generate_go_sdk() {
     # Optional parameters
     local GIT_REPO_ID=$4
     local SDK_REPO_URL=$5
+    local SDK_BRANCH=$6
 
     # Check required parameters
     if [[ -z ${GIT_HOST} ]]; then
@@ -75,6 +76,7 @@ generate_go_sdk() {
 
     # Install SDK project tools
     cd ${SDK_REPO_LOCAL_PATH}
+    git checkout ${SDK_BRANCH}
     make project-tools
 
     # Backup of the current state of the SDK services dir (services/)


### PR DESCRIPTION
This change reads the API version to use from a file that is committed to the repository as well. This will provide a stable and reproducible build. The flag can be overriden on the commandline. The behaviour is configured so that the current behaviour is still maintained