### PR TITLE
Fix generated json marshaller

### DIFF
--- a/templates/go/model_oneof.mustache
+++ b/templates/go/model_oneof.mustache
@@ -123,7 +123,7 @@ func (src {{classname}}) MarshalJSON() ([]byte, error) {
 	}
 
 {{/oneOf}}
-	return nil, nil // no data in oneOf schemas
+	return []byte("{}"), nil // no data in oneOf schemas => empty JSON object
 }
 
 // Get the actual instance


### PR DESCRIPTION
fix: if a struct is empty it is an empty json object. Returning nil w…ill break json marshalling