### PR TITLE
fix: Python sdk generation

### DIFF
--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -14,6 +14,9 @@ jobs:
   main-go:
     name: "[Go] Update SDK Repo"
     runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write
+      contents: write
     steps:
       - name: Install SSH Key
         uses: shimataro/ssh-key-action@v2
@@ -42,6 +45,9 @@ jobs:
   main-python:
     name: "[Python] Update SDK Repo"
     runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write
+      contents: write
     steps:
       - name: Install SSH Key
         uses: shimataro/ssh-key-action@v2
@@ -68,6 +74,7 @@ jobs:
           python -m venv .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip
-          pip install poetry
+          pip install poetry==1.8.5
           poetry config virtualenvs.create false
+          (cd ./sdk-repo-updated && make install-dev)
           scripts/sdk-create-pr.sh "generator-bot-${{ github.run_id }}" "Generated from GitHub run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" "git@github.com:stackitcloud/stackit-sdk-python.git" "python"


### PR DESCRIPTION
Use make install-dev in order to create the initial poetry.lock file. Use poetry version 1.8.5 also for creating PRs.