### PR TITLE
fix(python): linter throws errors in new poetry version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Install sdk
         working-directory: ./sdk-repo-updated
         run: |
-          pip install poetry==1.8.5
+          pip install poetry
           poetry config virtualenvs.create false
           python -m venv .venv          
           . .venv/bin/activate

--- a/.github/workflows/sdk-pr.yaml
+++ b/.github/workflows/sdk-pr.yaml
@@ -74,7 +74,7 @@ jobs:
           python -m venv .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip
-          pip install poetry==1.8.5
+          pip install poetry
           poetry config virtualenvs.create false
           (cd ./sdk-repo-updated && make install-dev)
           scripts/sdk-create-pr.sh "generator-bot-${{ github.run_id }}" "Generated from GitHub run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" "git@github.com:stackitcloud/stackit-sdk-python.git" "python"

--- a/templates/python/pyproject.mustache
+++ b/templates/python/pyproject.mustache
@@ -27,7 +27,7 @@ pydantic = ">=2.9.2"
 python-dateutil = ">=2.9.0.post0"
 
 [tool.poetry.group.dev.dependencies]
-black = ">=24.8.0"
+black = "<25.0.0" # Upgrading to a newer version requires bigger changes in the python generator. The formatting style in black has changed.
 pytest = ">=8.3.3"
 flake8 = [
   { version= ">=5.0.3", python="<3.12"},

--- a/templates/python/pyproject.mustache
+++ b/templates/python/pyproject.mustache
@@ -27,7 +27,7 @@ pydantic = ">=2.9.2"
 python-dateutil = ">=2.9.0.post0"
 
 [tool.poetry.group.dev.dependencies]
-black = "<25.0.0" # Upgrading to a newer version requires bigger changes in the python generator. The formatting style in black has changed.
+black = ">=24.8.0"
 pytest = ">=8.3.3"
 flake8 = [
   { version= ">=5.0.3", python="<3.12"},
@@ -95,14 +95,5 @@ inline-quotes = '"'
 docstring-quotes = '"""'
 multiline-quotes = '"""'
 ban-relative-imports = true
-per-file-ignores = """
-    # asserts are fine in tests, tests shouldn't be build optimized
-  ./tests/*: S101,
-    # F841: some variables get generated but may not be used, depending on the api-spec
-    # E501: long descriptions/string values might lead to lines that are too long    
-  ./src/stackit/*/models/*: F841,E501
-    # F841: some variables get generated but may not be used, depending on the api-spec
-    # E501: long descriptions/string values might lead to lines that are too long
-    # B028: stacklevel for deprecation warning is irrelevant
-  ./src/stackit/*/api/default_api.py: F841,B028,E501
-"""
+# Exclude generated code 
+extend-exclude = [ "src/stackit/*/models/*", "src/stackit/*/api/*", "src/stackit/*/*.py" ]


### PR DESCRIPTION
* the `black` python formatter changed the formatting style which causes some issues
  - set max version to avoid the new formatting style 