### PR TITLE
fix(go-generator): optional payload results in error, when it's not set

### DIFF
--- a/templates/go/client.mustache
+++ b/templates/go/client.mustache
@@ -307,7 +307,7 @@ func (c *APIClient) prepareRequest(
 	var body *bytes.Buffer
 
 	// Detect postBody type and post.
-	if postBody != nil {
+	if !IsNil(postBody) {
 		contentType := headerParams["Content-Type"]
 		if contentType == "" {
 			contentType = detectContentType(postBody)


### PR DESCRIPTION
- fix: execute of methods with an optional payload fail, when the payload is not set