### PR TITLE
chore: remove privateendpoint service from blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -6,4 +6,3 @@ kms
 
 airflow
 customer
-privateendpoint


### PR DESCRIPTION
issue was already fixed in #165 