### PR TITLE
chore(java-sdk): generate unknown value default cases for enums

### DIFF
--- a/openapi-generator-config-java.yml
+++ b/openapi-generator-config-java.yml
@@ -1,5 +1,6 @@
 templateDir: templates/java
 additionalProperties:
+  enumUnknownDefaultCase: true
   artifactUrl: https://github.com/stackitcloud/stackit-sdk-java
   developerName: STACKIT Developer Tools
   developerEmail: developer-tools@stackit.cloud


### PR DESCRIPTION
See docs of the OpenAPI generator: https://openapi-generator.tech/docs/generators/java/

Relevant part of the docs:

`enumUnknownDefaultCase`: If the server adds new enum cases, that are unknown by an old spec/client, the client will fail to parse the network response.With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the server sends an enum case that is not known by the client/spec, they can safely fallback to this case.
- false: No changes to the enum's are made, this is the default option.
- true: With this option enabled, each enum will have a new case, 'unknown_default_open_api', so that when the enum case sent by the server is not known by the client/spec, can safely be decoded to this case.