### PR TITLE
chore: bump go sdk generator to v7.22.0

### DIFF
--- a/languages/golang/openapi-generator-config.yml
+++ b/languages/golang/openapi-generator-config.yml
@@ -5,6 +5,7 @@ additionalProperties:
   enumClassPrefix: true
   generateInterfaces: true
   disallowAdditionalPropertiesIfNotPresent: false
+  enumUnknownDefaultCase: true
 templateDir: languages/golang/templates
 files:
   custom/api_mock.mustache:

--- a/languages/golang/templates/api.mustache
+++ b/languages/golang/templates/api.mustache
@@ -1,4 +1,4 @@
-{{! This template was customized to use the GenericOpenAPIError from the core module. See https://github.com/OpenAPITools/openapi-generator/blob/v7.20.0/modules/openapi-generator/src/main/resources/go/api.mustache for the original template }}
+{{! This template was customized to use the GenericOpenAPIError from the core module. See https://github.com/OpenAPITools/openapi-generator/blob/v7.22.0/modules/openapi-generator/src/main/resources/go/api.mustache for the original template }}
 {{>partial_header}}
 package {{packageName}}
 

--- a/languages/golang/templates/client.mustache
+++ b/languages/golang/templates/client.mustache
@@ -1,4 +1,4 @@
-{{! This template was customized to support the custom configuration options from the core module. See https://github.com/OpenAPITools/openapi-generator/blob/v7.20.0/modules/openapi-generator/src/main/resources/go/client.mustache for the original template }}
+{{! This template was customized to support the custom configuration options from the core module. See https://github.com/OpenAPITools/openapi-generator/blob/v7.22.0/modules/openapi-generator/src/main/resources/go/client.mustache for the original template }}
 {{>partial_header}}
 package {{packageName}}
 

--- a/languages/golang/templates/configuration.mustache
+++ b/languages/golang/templates/configuration.mustache
@@ -1,4 +1,4 @@
-{{! This template was ENTIRELY overwritten to support the custom configuration type and options from the STACKIT SDK core module. See https://github.com/OpenAPITools/openapi-generator/blob/v7.20.0/modules/openapi-generator/src/main/resources/go/configuration.mustache for the original template }}
+{{! This template was ENTIRELY overwritten to support the custom configuration type and options from the STACKIT SDK core module. See https://github.com/OpenAPITools/openapi-generator/blob/v7.22.0/modules/openapi-generator/src/main/resources/go/configuration.mustache for the original template }}
 {{>partial_header}}
 package {{packageName}}
 

--- a/scripts/generate-sdk/generate-sdk.sh
+++ b/scripts/generate-sdk/generate-sdk.sh
@@ -55,7 +55,8 @@ fi
 case "${LANGUAGE}" in
 go)
 # When the GENERATOR_VERSION changes, migrate also the templates in templates/go
-    GENERATOR_VERSION="v7.20.0" 
+# Renovate: datasource=github-tags depName=OpenAPITools/openapi-generator versioning=semver
+    GENERATOR_VERSION="v7.22.0"
     ;;
 python)
 # When the GENERATOR_VERSION changes, migrate also the templates in templates/python


### PR DESCRIPTION
relates to STACKITSDK-427