### PR TITLE
fix(ci): remove useless test step and lint-go job, adjust go build ma…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: ["1.21", "1.22", "1.23"]
+        go-version: ["1.25", "1.26"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Java
@@ -40,55 +40,6 @@ jobs:
       - name: Generate SDK
         shell: bash
         run: make generate-go-sdk
-      
-      - name: Test
-        working-directory: ./sdk-repo-updated
-        run: make test skip-non-generated-files=true
-
-  lint-go:
-    name: CI [Go]
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Install Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: ${{ env.JAVA_VERSION }}
-      
-      - name: Checkout
-        uses: actions/checkout@v4
-      
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION_BUILD }}
-      
-      - name: Install project tools and dependencies
-        shell: bash
-        run: make project-tools
-      
-      - name: Download OAS
-        shell: bash
-        run: make download-oas
-      
-      - name: Generate SDK
-        shell: bash
-        run: make generate-go-sdk
-      
-      - name: Remove waiters
-        working-directory: ./sdk-repo-updated
-        run: rm -r services/*/wait
-      
-      - name: Install SDK project tools and dependencies 
-        working-directory: ./sdk-repo-updated
-        run: make project-tools
-      
-      - name: Lint
-        working-directory: ./sdk-repo-updated
-        run: make lint skip-non-generated-files=true
 
   main-python:
     name: CI [Python]


### PR DESCRIPTION
…trix

- we only support the latest two go version
- test step only tested generated tests, which do not exist
- lint-go job removed waiters to prevent build failures on typecheck errors. This breaks typecheck in examples. Removing examples would need editing of go.work file before linting.
- linting was called with `skip-non-generated-files=true`, but golangci-lint skips generated files by default. So this job linted nothing.