### PR TITLE
feat(go): enable workflows SDK generation

### DIFF
--- a/languages/golang/blocklist.txt
+++ b/languages/golang/blocklist.txt
@@ -5,4 +5,3 @@ functionsregistry
 notebooks
 pim
 stackitmarketplace
-workflows


### PR DESCRIPTION
Remove workflows from the golang blocklist now that:
- stackit-api has x-stackit-sdk.include: true on the workflows OAS
- The OAS has been published to stackit-api-specifications